### PR TITLE
Fix inspect state flag duplication and dedupe timezone parsing

### DIFF
--- a/Sources/DokkuStatus/Domain/Models.swift
+++ b/Sources/DokkuStatus/Domain/Models.swift
@@ -276,43 +276,11 @@ struct AppLetsEncryptStatus: Codable, Equatable {
             return timeZone
         }
 
-        guard let seconds = Self.secondsFromGMT(offset: serverTimeZoneOffset) else {
+        guard let seconds = TimeZoneOffsetParser.secondsFromGMT(offset: serverTimeZoneOffset) else {
             return nil
         }
 
         return TimeZone(secondsFromGMT: seconds)
-    }
-
-    private static func secondsFromGMT(offset: String?) -> Int? {
-        guard let raw = offset?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
-            return nil
-        }
-
-        let normalized = raw.replacingOccurrences(of: ":", with: "")
-        guard normalized.count == 5 else {
-            return nil
-        }
-
-        guard let signCharacter = normalized.first else {
-            return nil
-        }
-        let digits = normalized.dropFirst()
-        guard let value = Int(digits) else {
-            return nil
-        }
-
-        let hours = value / 100
-        let minutes = value % 100
-        let seconds = (hours * 3600) + (minutes * 60)
-
-        switch signCharacter {
-        case "+":
-            return seconds
-        case "-":
-            return -seconds
-        default:
-            return nil
-        }
     }
 }
 

--- a/Sources/DokkuStatus/Domain/TimeZoneOffsetParser.swift
+++ b/Sources/DokkuStatus/Domain/TimeZoneOffsetParser.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum TimeZoneOffsetParser {
+    static func normalizedUTCOffset(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+
+        let normalized = value.replacingOccurrences(of: ":", with: "")
+        guard normalized.count == 5, normalized.first == "+" || normalized.first == "-" else {
+            return nil
+        }
+
+        let sign = normalized.prefix(1)
+        let digits = normalized.dropFirst()
+        guard digits.count == 4 else {
+            return nil
+        }
+
+        let hours = digits.prefix(2)
+        let minutes = digits.suffix(2)
+        return "\(sign)\(hours)\(minutes)"
+    }
+
+    static func secondsFromGMT(offset: String?) -> Int? {
+        guard let normalized = normalizedUTCOffset(offset) else {
+            return nil
+        }
+
+        guard let signCharacter = normalized.first, let value = Int(normalized.dropFirst()) else {
+            return nil
+        }
+
+        let hours = value / 100
+        let minutes = value % 100
+        let seconds = (hours * 3600) + (minutes * 60)
+
+        switch signCharacter {
+        case "+":
+            return seconds
+        case "-":
+            return -seconds
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/DokkuStatus/Infra/LiveDokkuClient.swift
+++ b/Sources/DokkuStatus/Infra/LiveDokkuClient.swift
@@ -103,7 +103,7 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
         let parsedRemoteTimeZone = RemoteTimeZoneContext(
             identifier: normalizedString(remoteTimeZoneIdentifier),
             abbreviation: normalizedString(remoteTimeZoneAbbreviation),
-            offset: normalizedUTCOffset(remoteTimeZoneOffset)
+            offset: TimeZoneOffsetParser.normalizedUTCOffset(remoteTimeZoneOffset)
         )
         let remoteTimeZone: RemoteTimeZoneContext? =
             (parsedRemoteTimeZone.identifier != nil ||
@@ -229,11 +229,6 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
 
             if let statusText {
                 statuses.append(statusText)
-                if statusText.lowercased().hasPrefix("running") {
-                    hasRunning = true
-                } else {
-                    hasNonRunning = true
-                }
             }
 
             let processIdentifier = processIdentifier(for: container)
@@ -362,7 +357,7 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
 
         let identifier = columns.indices.contains(0) ? normalizedString(columns[0]) : nil
         let abbreviation = columns.indices.contains(1) ? normalizedString(columns[1]) : nil
-        let offset = columns.indices.contains(2) ? normalizedUTCOffset(columns[2]) : nil
+        let offset = columns.indices.contains(2) ? TimeZoneOffsetParser.normalizedUTCOffset(columns[2]) : nil
 
         if identifier == nil, abbreviation == nil, offset == nil {
             return nil
@@ -384,27 +379,6 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.timeZone = remoteTimeZone
         return formatter.date(from: normalizedValue)
-    }
-
-    private static func normalizedUTCOffset(_ value: String?) -> String? {
-        guard let value = normalizedString(value) else {
-            return nil
-        }
-
-        let normalized = value.replacingOccurrences(of: ":", with: "")
-        guard normalized.count == 5, normalized.first == "+" || normalized.first == "-" else {
-            return nil
-        }
-
-        let sign = normalized.prefix(1)
-        let digits = normalized.dropFirst()
-        guard digits.count == 4 else {
-            return nil
-        }
-
-        let hours = digits.prefix(2)
-        let minutes = digits.suffix(2)
-        return "\(sign)\(hours)\(minutes)"
     }
 
     private static func uniquePreservingOrder(_ values: [String]) -> [String] {
@@ -698,35 +672,11 @@ private struct RemoteTimeZoneContext {
             return timeZone
         }
 
-        guard let offset, let seconds = Self.secondsFromGMT(offset: offset) else {
+        guard let seconds = TimeZoneOffsetParser.secondsFromGMT(offset: offset) else {
             return nil
         }
 
         return TimeZone(secondsFromGMT: seconds)
-    }
-
-    private static func secondsFromGMT(offset: String) -> Int? {
-        let normalized = offset.replacingOccurrences(of: ":", with: "")
-        guard
-            normalized.count == 5,
-            let signCharacter = normalized.first,
-            let value = Int(normalized.dropFirst())
-        else {
-            return nil
-        }
-
-        let hours = value / 100
-        let minutes = value % 100
-        let seconds = (hours * 3600) + (minutes * 60)
-
-        switch signCharacter {
-        case "+":
-            return seconds
-        case "-":
-            return -seconds
-        default:
-            return nil
-        }
     }
 }
 

--- a/Tests/DokkuStatusTests/LiveDokkuClientTests.swift
+++ b/Tests/DokkuStatusTests/LiveDokkuClientTests.swift
@@ -108,6 +108,24 @@ final class LiveDokkuClientTests: XCTestCase {
         XCTAssertEqual(parsed.rawStatus, "exited")
     }
 
+    func testParseInspectStatusPrefersRunningFlagOverStatusString() throws {
+        let output = """
+        [
+          {
+            "State": {
+              "Running": false,
+              "Status": "running"
+            }
+          }
+        ]
+        """
+
+        let parsed = try LiveDokkuClient.parseInspectStatus(output, appName: "app-one")
+
+        XCTAssertEqual(parsed.state, .notRunning)
+        XCTAssertEqual(parsed.rawStatus, "running")
+    }
+
     func testParseInspectStatusFromLiveAppAlphaRunning() throws {
         let output = try fixture(named: "ps-inspect-app-alpha.json")
 

--- a/Tests/DokkuStatusTests/TimeZoneOffsetParserTests.swift
+++ b/Tests/DokkuStatusTests/TimeZoneOffsetParserTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import DokkuStatus
+
+final class TimeZoneOffsetParserTests: XCTestCase {
+    func testNormalizedUTCOffsetAcceptsCompactAndColonFormats() {
+        XCTAssertEqual(TimeZoneOffsetParser.normalizedUTCOffset("+0530"), "+0530")
+        XCTAssertEqual(TimeZoneOffsetParser.normalizedUTCOffset("-05:00"), "-0500")
+    }
+
+    func testSecondsFromGMTParsesSignedOffsets() {
+        XCTAssertEqual(TimeZoneOffsetParser.secondsFromGMT(offset: "+0530"), 19_800)
+        XCTAssertEqual(TimeZoneOffsetParser.secondsFromGMT(offset: "-0500"), -18_000)
+        XCTAssertNil(TimeZoneOffsetParser.secondsFromGMT(offset: "0500"))
+        XCTAssertNil(TimeZoneOffsetParser.secondsFromGMT(offset: "+0A00"))
+    }
+}


### PR DESCRIPTION
## Summary
- remove duplicate running/non-running flag updates in inspect parsing
- add regression coverage when state running and status text disagree
- extract shared TimeZoneOffsetParser and use it from both AppLetsEncryptStatus and RemoteTimeZoneContext
- add parser unit tests

## Validation
- swift test

Closes #6
Closes #7