### PR TITLE
Bound app inspect concurrency to two workers

### DIFF
--- a/Sources/DokkuStatus/Infra/LiveDokkuClient.swift
+++ b/Sources/DokkuStatus/Infra/LiveDokkuClient.swift
@@ -20,6 +20,7 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
     private let logger = Logger(subsystem: "DokkuStatus", category: "dokku")
     private static let letsEncryptTimeZoneProbeCommand =
         "printf '%s\\t%s\\t%s\\n' \"$(cat /etc/timezone 2>/dev/null || true)\" \"$(date +%Z)\" \"$(date +%z)\""
+    private static let inspectConcurrencyLimit = 2
 
     init(runner: SSHRunning = SSHProcessRunner()) {
         self.runner = runner
@@ -39,48 +40,107 @@ final class LiveDokkuClient: DokkuClient, @unchecked Sendable {
         )
 
         let appNames = Self.parseAppsList(appsResult.stdout)
-        var statuses: [AppStatus] = []
-        statuses.reserveCapacity(appNames.count)
-
-        for appName in appNames {
-            do {
-                let reportResult = try await runner.run(
-                    target: target,
-                    port: validatedConfig.port,
-                    remoteCommand: "dokku ps:inspect \(Self.shellEscape(appName))",
-                    timeout: 15
-                )
-
-                let parsedStatus = try Self.parseInspectResult(reportResult.stdout, appName: appName)
-
-                statuses.append(
-                    AppStatus(
-                        appName: appName,
-                        state: parsedStatus.state,
-                        rawStatus: parsedStatus.rawStatus,
-                        checkedAt: checkedAt,
-                        errorMessage: nil,
-                        details: parsedStatus.details,
-                        letsEncrypt: letsEncryptByApp[appName.lowercased()]
-                    )
-                )
-            } catch {
-                logger.error("Failed to fetch status for app \(appName, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                statuses.append(
-                    AppStatus(
-                        appName: appName,
-                        state: .unknown,
-                        rawStatus: nil,
-                        checkedAt: checkedAt,
-                        errorMessage: error.localizedDescription,
-                        details: nil,
-                        letsEncrypt: letsEncryptByApp[appName.lowercased()]
-                    )
-                )
-            }
-        }
+        let statuses = await fetchStatuses(
+            appNames: appNames,
+            target: target,
+            port: validatedConfig.port,
+            checkedAt: checkedAt,
+            letsEncryptByApp: letsEncryptByApp
+        )
 
         return statuses.sorted { $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending }
+    }
+
+    private func fetchStatuses(
+        appNames: [String],
+        target: String,
+        port: Int,
+        checkedAt: Date,
+        letsEncryptByApp: [String: AppLetsEncryptStatus]
+    ) async -> [AppStatus] {
+        await withTaskGroup(of: AppStatus.self, returning: [AppStatus].self) { group in
+            var appIterator = appNames.makeIterator()
+            var statuses: [AppStatus] = []
+            statuses.reserveCapacity(appNames.count)
+
+            let initialTaskCount = min(Self.inspectConcurrencyLimit, appNames.count)
+            for _ in 0..<initialTaskCount {
+                guard let appName = appIterator.next() else {
+                    break
+                }
+
+                let letsEncrypt = letsEncryptByApp[appName.lowercased()]
+                group.addTask { [self] in
+                    await fetchStatus(
+                        appName: appName,
+                        target: target,
+                        port: port,
+                        checkedAt: checkedAt,
+                        letsEncrypt: letsEncrypt
+                    )
+                }
+            }
+
+            while let status = await group.next() {
+                statuses.append(status)
+
+                guard let appName = appIterator.next() else {
+                    continue
+                }
+
+                let letsEncrypt = letsEncryptByApp[appName.lowercased()]
+                group.addTask { [self] in
+                    await fetchStatus(
+                        appName: appName,
+                        target: target,
+                        port: port,
+                        checkedAt: checkedAt,
+                        letsEncrypt: letsEncrypt
+                    )
+                }
+            }
+
+            return statuses
+        }
+    }
+
+    private func fetchStatus(
+        appName: String,
+        target: String,
+        port: Int,
+        checkedAt: Date,
+        letsEncrypt: AppLetsEncryptStatus?
+    ) async -> AppStatus {
+        do {
+            let reportResult = try await runner.run(
+                target: target,
+                port: port,
+                remoteCommand: "dokku ps:inspect \(Self.shellEscape(appName))",
+                timeout: 15
+            )
+
+            let parsedStatus = try Self.parseInspectResult(reportResult.stdout, appName: appName)
+            return AppStatus(
+                appName: appName,
+                state: parsedStatus.state,
+                rawStatus: parsedStatus.rawStatus,
+                checkedAt: checkedAt,
+                errorMessage: nil,
+                details: parsedStatus.details,
+                letsEncrypt: letsEncrypt
+            )
+        } catch {
+            logger.error("Failed to fetch status for app \(appName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return AppStatus(
+                appName: appName,
+                state: .unknown,
+                rawStatus: nil,
+                checkedAt: checkedAt,
+                errorMessage: error.localizedDescription,
+                details: nil,
+                letsEncrypt: letsEncrypt
+            )
+        }
     }
 
     static func parseAppsList(_ output: String) -> [String] {

--- a/Tests/DokkuStatusTests/LiveDokkuClientTests.swift
+++ b/Tests/DokkuStatusTests/LiveDokkuClientTests.swift
@@ -294,6 +294,18 @@ final class LiveDokkuClientTests: XCTestCase {
         XCTAssertThrowsError(try LiveDokkuClient.parseInspectStatus("No status here", appName: "app-one"))
     }
 
+    func testFetchAppStatusesLimitsInspectConcurrencyToTwo() async throws {
+        let runner = InspectConcurrencyTrackingRunner(appNames: ["app-a", "app-b", "app-c", "app-d"])
+        let client = LiveDokkuClient(runner: runner)
+        let config = DokkuHostConfig(host: "example.com", user: "dokku", port: 22, sshAlias: nil)
+
+        let statuses = try await client.fetchAppStatuses(config: config)
+        let maxObservedConcurrency = await runner.maxObservedConcurrency()
+
+        XCTAssertEqual(statuses.map(\.appName), ["app-a", "app-b", "app-c", "app-d"])
+        XCTAssertEqual(maxObservedConcurrency, 2)
+    }
+
     func testFetchAppStatusesReturnsUnknownForPerAppFailures() async throws {
         let runner = MockSSHRunner(
             responses: [
@@ -398,6 +410,41 @@ private actor MockSSHRunner: SSHRunning {
         }
 
         return try response.get()
+    }
+}
+
+private actor InspectConcurrencyTrackingRunner: SSHRunning {
+    private let appNames: [String]
+    private var activeInspectCount = 0
+    private var maxInspectConcurrency = 0
+
+    init(appNames: [String]) {
+        self.appNames = appNames
+    }
+
+    func run(target: String, port: Int, remoteCommand: String, timeout: TimeInterval) async throws -> SSHCommandResult {
+        if remoteCommand == "dokku apps:list" {
+            return SSHCommandResult(stdout: appNames.joined(separator: "\n") + "\n", stderr: "", exitCode: 0)
+        }
+
+        if remoteCommand.hasPrefix("dokku ps:inspect ") {
+            activeInspectCount += 1
+            maxInspectConcurrency = max(maxInspectConcurrency, activeInspectCount)
+            defer { activeInspectCount -= 1 }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return SSHCommandResult(
+                stdout: "[{\"State\":{\"Running\":true,\"Status\":\"running\"}}]",
+                stderr: "",
+                exitCode: 0
+            )
+        }
+
+        throw MockError.failed
+    }
+
+    func maxObservedConcurrency() -> Int {
+        maxInspectConcurrency
     }
 }
 


### PR DESCRIPTION
## Summary
- replace sequential inspect loop with bounded task-group scheduling
- cap in-flight inspect commands at 2
- preserve per-app failure mapping to unknown
- keep final app ordering deterministic via existing sort
- add async regression test that verifies max inspect concurrency is exactly two

## Validation
- swift test

Closes #2